### PR TITLE
allow class if morph has been specified

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -218,7 +218,7 @@ trait QueriesRelationships
                         };
                     }
 
-                    $query->where($relation->getMorphType(), '=', $type)
+                    $query->where($relation->getMorphType(), '=', Relation::getMorphAlias($type) ?? $type)
                         ->whereHas($belongsTo, $callback, $operator, $count);
                 });
             }

--- a/src/Illuminate/Database/Eloquent/Relations/Relation.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Relation.php
@@ -343,6 +343,19 @@ abstract class Relation
     }
 
     /**
+     * Get the alias for the given class.
+     *
+     * @param  string  $class
+     * @return string|null
+     */
+    public static function getMorphAlias($class)
+    {
+        $alias = array_search($class, static::$morphMap);
+
+        return $alias === false ? null : $alias;
+    }
+
+    /**
      * Builds a table-keyed array from model class names.
      *
      * @param  string[]|null  $models

--- a/tests/Database/DatabaseEloquentRelationTest.php
+++ b/tests/Database/DatabaseEloquentRelationTest.php
@@ -234,6 +234,29 @@ class DatabaseEloquentRelationTest extends TestCase
         Relation::morphMap([], false);
     }
 
+    public function testGetMorphAliasReturnsExpectedAlias()
+    {
+        Relation::morphMap(['expected_alias' => MappedClass::class]);
+
+        $this->assertSame('expected_alias', Relation::getMorphAlias(MappedClass::class));
+
+        Relation::morphMap([], false);
+    }
+
+    public function testGetMorphAliasReturnsNullWhenNoAliasFound()
+    {
+        $this->assertNull(Relation::getMorphAlias(MissingClass::class));
+    }
+
+    public function testFalsyMorphAliasValuesAreReturned()
+    {
+        Relation::morphMap(['' => MappedClass::class]);
+
+        $this->assertSame('', Relation::getMorphAlias(MappedClass::class));
+
+        Relation::morphMap([], false);
+    }
+
     public function testMacroable()
     {
         Relation::macro('foo', function () {

--- a/tests/Integration/Database/EloquentWhereHasMorphTest.php
+++ b/tests/Integration/Database/EloquentWhereHasMorphTest.php
@@ -91,6 +91,24 @@ class EloquentWhereHasMorphTest extends DatabaseTestCase
         }
     }
 
+    public function testWhereHasMorphWithMorphMapButUsingTheClassInstead()
+    {
+        Relation::morphMap(['posts' => Post::class]);
+
+        Comment::where('commentable_type', Post::class)->update(['commentable_type' => 'posts']);
+
+        try {
+            $comments = Comment::whereHasMorph('commentable', [Post::class, Video::class], function (Builder $query) {
+                $query->where('title', 'foo');
+            })->get();
+
+            $this->assertEquals([1, 4], $comments->pluck('id')->all());
+        } finally {
+            Relation::morphMap([], false);
+        }
+    }
+
+
     public function testWhereHasMorphWithRelationConstraint()
     {
         $comments = Comment::whereHasMorph('commentableWithConstraint', Video::class, function (Builder $query) {


### PR DESCRIPTION
Allow a class even when it has an existing morph map value